### PR TITLE
ci: upgrade workflows to Node 24-compatible GitHub Actions

### DIFF
--- a/.github/workflows/chunithm-update-constants.yml
+++ b/.github/workflows/chunithm-update-constants.yml
@@ -12,17 +12,17 @@ jobs:
 
     steps:
       - name: Set timezone
-        uses: szenius/set-timezone@v1.2
+        uses: szenius/set-timezone@v2.0
         with:
           timezoneLinux: "Asia/Tokyo"
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: 3.x
 

--- a/.github/workflows/chunithm-update-intl.yml
+++ b/.github/workflows/chunithm-update-intl.yml
@@ -12,17 +12,17 @@ jobs:
 
     steps:
       - name: Set timezone
-        uses: szenius/set-timezone@v1.2
+        uses: szenius/set-timezone@v2.0
         with:
           timezoneLinux: "Asia/Tokyo"
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: 3.x
 

--- a/.github/workflows/chunithm-update-songs.yml
+++ b/.github/workflows/chunithm-update-songs.yml
@@ -12,17 +12,17 @@ jobs:
 
     steps:
       - name: Set timezone
-        uses: szenius/set-timezone@v1.2
+        uses: szenius/set-timezone@v2.0
         with:
           timezoneLinux: "Asia/Tokyo"
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: 3.x
 

--- a/.github/workflows/chunithm-update-wiki-chartguide-all.yml
+++ b/.github/workflows/chunithm-update-wiki-chartguide-all.yml
@@ -10,17 +10,17 @@ jobs:
 
     steps:
       - name: Set timezone
-        uses: szenius/set-timezone@v1.2
+        uses: szenius/set-timezone@v2.0
         with:
           timezoneLinux: "Asia/Tokyo"
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: 3.x
 

--- a/.github/workflows/chunithm-update-wiki-chartguide.yml
+++ b/.github/workflows/chunithm-update-wiki-chartguide.yml
@@ -12,17 +12,17 @@ jobs:
 
     steps:
       - name: Set timezone
-        uses: szenius/set-timezone@v1.2
+        uses: szenius/set-timezone@v2.0
         with:
           timezoneLinux: "Asia/Tokyo"
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: 3.x
 

--- a/.github/workflows/maimai-update-constants.yml
+++ b/.github/workflows/maimai-update-constants.yml
@@ -12,17 +12,17 @@ jobs:
 
     steps:
       - name: Set timezone
-        uses: szenius/set-timezone@v1.2
+        uses: szenius/set-timezone@v2.0
         with:
           timezoneLinux: "Asia/Tokyo"
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: 3.x
 

--- a/.github/workflows/maimai-update-intl.yml
+++ b/.github/workflows/maimai-update-intl.yml
@@ -12,17 +12,17 @@ jobs:
 
     steps:
       - name: Set timezone
-        uses: szenius/set-timezone@v1.2
+        uses: szenius/set-timezone@v2.0
         with:
           timezoneLinux: "Asia/Tokyo"
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: 3.x
 

--- a/.github/workflows/maimai-update-songs.yml
+++ b/.github/workflows/maimai-update-songs.yml
@@ -12,17 +12,17 @@ jobs:
 
     steps:
       - name: Set timezone
-        uses: szenius/set-timezone@v1.2
+        uses: szenius/set-timezone@v2.0
         with:
           timezoneLinux: "Asia/Tokyo"
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: 3.x
 

--- a/.github/workflows/maimai-update-wiki-all.yml
+++ b/.github/workflows/maimai-update-wiki-all.yml
@@ -10,17 +10,17 @@ jobs:
 
     steps:
       - name: Set timezone
-        uses: szenius/set-timezone@v1.2
+        uses: szenius/set-timezone@v2.0
         with:
           timezoneLinux: "Asia/Tokyo"
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: 3.x
 

--- a/.github/workflows/maimai-update-wiki.yml
+++ b/.github/workflows/maimai-update-wiki.yml
@@ -12,17 +12,17 @@ jobs:
 
     steps:
       - name: Set timezone
-        uses: szenius/set-timezone@v1.2
+        uses: szenius/set-timezone@v2.0
         with:
           timezoneLinux: "Asia/Tokyo"
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: 3.x
 

--- a/.github/workflows/ongeki-update-constants.yml
+++ b/.github/workflows/ongeki-update-constants.yml
@@ -12,17 +12,17 @@ jobs:
 
     steps:
       - name: Set timezone
-        uses: szenius/set-timezone@v1.2
+        uses: szenius/set-timezone@v2.0
         with:
           timezoneLinux: "Asia/Tokyo"
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: 3.x
 

--- a/.github/workflows/ongeki-update-songs.yml
+++ b/.github/workflows/ongeki-update-songs.yml
@@ -12,17 +12,17 @@ jobs:
 
     steps:
       - name: Set timezone
-        uses: szenius/set-timezone@v1.2
+        uses: szenius/set-timezone@v2.0
         with:
           timezoneLinux: "Asia/Tokyo"
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: 3.x
 

--- a/.github/workflows/ongeki-update-wiki-chartguide-all.yml
+++ b/.github/workflows/ongeki-update-wiki-chartguide-all.yml
@@ -10,17 +10,17 @@ jobs:
 
     steps:
       - name: Set timezone
-        uses: szenius/set-timezone@v1.2
+        uses: szenius/set-timezone@v2.0
         with:
           timezoneLinux: "Asia/Tokyo"
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: 3.x
 

--- a/.github/workflows/ongeki-update-wiki-chartguide.yml
+++ b/.github/workflows/ongeki-update-wiki-chartguide.yml
@@ -12,17 +12,17 @@ jobs:
 
     steps:
       - name: Set timezone
-        uses: szenius/set-timezone@v1.2
+        uses: szenius/set-timezone@v2.0
         with:
           timezoneLinux: "Asia/Tokyo"
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: 3.x
 

--- a/.github/workflows/site-build-deploy.yml
+++ b/.github/workflows/site-build-deploy.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Pages
         uses: actions/configure-pages@v4


### PR DESCRIPTION
## Summary
- upgrade actions/checkout from v4 to v6
- upgrade actions/setup-python from v4 to v6
- upgrade szenius/set-timezone from v1.2 to v2.0
- apply updates consistently across all workflow files

## Why
GitHub Actions logs showed Node.js 20 deprecation warnings. This aligns workflows with Node 24-compatible action versions ahead of enforcement dates.

## Notes
This change addresses deprecation risk; the earlier run failures appeared to be runner communication loss rather than step-level script failures.