### PR TITLE
ci: centralize PR creation and auto-chunk long output logs

### DIFF
--- a/.github/workflows/chunithm-update-constants.yml
+++ b/.github/workflows/chunithm-update-constants.yml
@@ -49,13 +49,8 @@ jobs:
           # git push --force --set-upstream origin chunithm-staging
 
       - name: Run constants script and capture output
-        id: run_script
         run: |
-          {
-            echo "OUTPUT_LOG<<EOF"
-            python scripts/update-const.py --chunithm --all --nocolors --escape --markdown --no_timestamp --no_verbose
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
+          python -u scripts/update-const.py --chunithm --all --nocolors --escape --markdown --no_timestamp --no_verbose 2>&1 | tee output.log
 
       - name: Extract datestamp from script output
         id: extract_date
@@ -83,17 +78,11 @@ jobs:
       - name: Checkout existing PR or create new
         if: steps.commit_changes.outputs.HAS_DIFFS == 'true'
         run: |
-          if [[ $(gh pr list --state open --head chunithm-staging | grep chunithm-staging) ]]; then
-            echo "PR currently open. Add comment to existing open PR"
-            gh pr comment chunithm-staging \
-              --body "${{ steps.run_script.outputs.OUTPUT_LOG }}"
-          else
-            echo "No currently open PR for chunithm-staging. Create new PR"
-            gh pr create \
-              -B ${{ github.ref_name }} \
-              -H "chunithm-staging" \
-              --title "[Automation] CHUNITHM: Update website with updated song data (${{ steps.extract_date.outputs.DATESTAMP }})" \
-              --body "${{ steps.run_script.outputs.OUTPUT_LOG }}"
-          fi
+          python scripts/post-pr.py \
+            --head "chunithm-staging" \
+            --base "${{ github.ref_name }}" \
+            --title "[Automation] CHUNITHM: Update website with updated song data (${{ steps.extract_date.outputs.DATESTAMP }})" \
+            --log-file "output.log"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.github/workflows/chunithm-update-intl.yml
+++ b/.github/workflows/chunithm-update-intl.yml
@@ -49,13 +49,8 @@ jobs:
           # git push --force --set-upstream origin chunithm-staging
 
       - name: Run wiki script and capture output
-        id: run_script
         run: |
-          {
-            echo "OUTPUT_LOG<<EOF"
-            python -u scripts/update-intl.py --chunithm --nocolors --escape --markdown --no_timestamp --no_verbose | tee /dev/stderr
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
+          python -u scripts/update-intl.py --chunithm --nocolors --escape --markdown --no_timestamp --no_verbose 2>&1 | tee output.log
 
       - name: Extract datestamp from script output
         id: extract_date
@@ -83,17 +78,11 @@ jobs:
       - name: Checkout existing PR or create new
         if: steps.commit_changes.outputs.HAS_DIFFS == 'true'
         run: |
-          if [[ $(gh pr list --state open --head chunithm-staging | grep chunithm-staging) ]]; then
-            echo "PR currently open. Add comment to existing open PR"
-            gh pr comment chunithm-staging \
-              --body "${{ steps.run_script.outputs.OUTPUT_LOG }}"
-          else
-            echo "No currently open PR for chunithm-staging. Create new PR"
-            gh pr create \
-              -B ${{ github.ref_name }} \
-              -H "chunithm-staging" \
-              --title "[Automation] CHUNITHM: Update website with updated song data (${{ steps.extract_date.outputs.DATESTAMP }})" \
-              --body "${{ steps.run_script.outputs.OUTPUT_LOG }}"
-          fi
+          python scripts/post-pr.py \
+            --head "chunithm-staging" \
+            --base "${{ github.ref_name }}" \
+            --title "[Automation] CHUNITHM: Update website with updated song data (${{ steps.extract_date.outputs.DATESTAMP }})" \
+            --log-file "output.log"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.github/workflows/chunithm-update-songs.yml
+++ b/.github/workflows/chunithm-update-songs.yml
@@ -49,13 +49,8 @@ jobs:
           # git push --force --set-upstream origin chunithm-staging
 
       - name: Run main script and capture output
-        id: run_script
         run: |
-          {
-            echo "OUTPUT_LOG<<EOF"
-            python scripts/update-songs.py --chunithm --nocolors --escape --markdown --no_timestamp --no_verbose
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
+          python -u scripts/update-songs.py --chunithm --nocolors --escape --markdown --no_timestamp --no_verbose 2>&1 | tee output.log
 
       - name: Extract datestamp from script output
         id: extract_date
@@ -64,16 +59,6 @@ jobs:
           # Use today's date instead because Chunithm default json doesn't have date data...
           # echo "datestamp=$(date '+%Y%m%d')" >> "$GITHUB_OUTPUT"
 
-      # - name: Check script output
-      #   id: check_script
-      #   run: |
-      #     if [[ "${{ steps.run_script.outputs.OUTPUT_LOG }}" == *"New song added"* ]]; then
-      #       echo "New song data downloaded. Creating a pull request."
-      #       echo "CREATE_PR=true" >> "$GITHUB_OUTPUT"
-      #     else
-      #       echo "Nothing updated. Skipping pull request creation."
-      #       echo "CREATE_PR=false" >> "$GITHUB_OUTPUT"
-      #     fi
 
       - name: Commit changes
         id: commit_changes
@@ -95,17 +80,11 @@ jobs:
       - name: Checkout existing PR or create new
         if: steps.commit_changes.outputs.HAS_DIFFS == 'true'
         run: |
-          if [[ $(gh pr list --state open --head chunithm-staging | grep chunithm-staging) ]]; then
-            echo "PR currently open. Add comment to existing open PR"
-            gh pr comment chunithm-staging \
-              --body "${{ steps.run_script.outputs.OUTPUT_LOG }}"
-          else
-            echo "No currently open PR for chunithm-staging. Create new PR"
-            gh pr create \
-              -B ${{ github.ref_name }} \
-              -H "chunithm-staging" \
-              --title "[Automation] CHUNITHM: Add new songs (${{ steps.extract_date.outputs.DATESTAMP }})" \
-              --body "${{ steps.run_script.outputs.OUTPUT_LOG }}"
-          fi
+          python scripts/post-pr.py \
+            --head "chunithm-staging" \
+            --base "${{ github.ref_name }}" \
+            --title "[Automation] CHUNITHM: Add new songs (${{ steps.extract_date.outputs.DATESTAMP }})" \
+            --log-file "output.log"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.github/workflows/chunithm-update-wiki-chartguide-all.yml
+++ b/.github/workflows/chunithm-update-wiki-chartguide-all.yml
@@ -47,14 +47,11 @@ jobs:
           # git push --force --set-upstream origin chunithm-staging
 
       - name: Run wiki script and capture output
-        id: run_script
         run: |
           {
-            echo "OUTPUT_LOG<<EOF"
-            python scripts/update-wiki-data.py --chunithm --all --nocolors --escape --markdown --noskip --no_timestamp --no_verbose
-            python scripts/update-chartguide-data.py --chunithm --all --nocolors --escape --markdown --no_timestamp --no_verbose
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
+            python -u scripts/update-wiki-data.py --chunithm --all --nocolors --escape --markdown --noskip --no_timestamp --no_verbose
+            python -u scripts/update-chartguide-data.py --chunithm --all --nocolors --escape --markdown --no_timestamp --no_verbose
+          } 2>&1 | tee output.log
 
       - name: Extract datestamp from script output
         id: extract_date
@@ -82,17 +79,11 @@ jobs:
       - name: Checkout existing PR or create new
         if: steps.commit_changes.outputs.HAS_DIFFS == 'true'
         run: |
-          if [[ $(gh pr list --state open --head chunithm-staging | grep chunithm-staging) ]]; then
-            echo "PR currently open. Add comment to existing open PR"
-            gh pr comment chunithm-staging \
-              --body "${{ steps.run_script.outputs.OUTPUT_LOG }}"
-          else
-            echo "No currently open PR for chunithm-staging. Create new PR"
-            gh pr create \
-              -B ${{ github.ref_name }} \
-              -H "chunithm-staging" \
-              --title "[Automation] CHUNITHM: Update website with updated song data (all songs)" \
-              --body "${{ steps.run_script.outputs.OUTPUT_LOG }}"
-          fi
+          python scripts/post-pr.py \
+            --head "chunithm-staging" \
+            --base "${{ github.ref_name }}" \
+            --title "[Automation] CHUNITHM: Update website with updated song data (all songs)" \
+            --log-file "output.log"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.github/workflows/chunithm-update-wiki-chartguide.yml
+++ b/.github/workflows/chunithm-update-wiki-chartguide.yml
@@ -49,14 +49,11 @@ jobs:
           # git push --force --set-upstream origin chunithm-staging
 
       - name: Run wiki script and capture output
-        id: run_script
         run: |
           {
-            echo "OUTPUT_LOG<<EOF"
-            python scripts/update-wiki-data.py --chunithm --nocolors --escape --markdown --noskip --no_timestamp --no_verbose
-            python scripts/update-chartguide-data.py --chunithm --nocolors --escape --markdown --no_timestamp --no_verbose
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
+            python -u scripts/update-wiki-data.py --chunithm --nocolors --escape --markdown --noskip --no_timestamp --no_verbose
+            python -u scripts/update-chartguide-data.py --chunithm --nocolors --escape --markdown --no_timestamp --no_verbose
+          } 2>&1 | tee output.log
 
       - name: Extract datestamp from script output
         id: extract_date
@@ -84,17 +81,11 @@ jobs:
       - name: Checkout existing PR or create new
         if: steps.commit_changes.outputs.HAS_DIFFS == 'true'
         run: |
-          if [[ $(gh pr list --state open --head chunithm-staging | grep chunithm-staging) ]]; then
-            echo "PR currently open. Add comment to existing open PR"
-            gh pr comment chunithm-staging \
-              --body "${{ steps.run_script.outputs.OUTPUT_LOG }}"
-          else
-            echo "No currently open PR for chunithm-staging. Create new PR"
-            gh pr create \
-              -B ${{ github.ref_name }} \
-              -H "chunithm-staging" \
-              --title "[Automation] CHUNITHM: Update website with updated song data (${{ steps.extract_date.outputs.DATESTAMP }})" \
-              --body "${{ steps.run_script.outputs.OUTPUT_LOG }}"
-          fi
+          python scripts/post-pr.py \
+            --head "chunithm-staging" \
+            --base "${{ github.ref_name }}" \
+            --title "[Automation] CHUNITHM: Update website with updated song data (${{ steps.extract_date.outputs.DATESTAMP }})" \
+            --log-file "output.log"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.github/workflows/maimai-update-constants.yml
+++ b/.github/workflows/maimai-update-constants.yml
@@ -49,13 +49,8 @@ jobs:
           # git push --force --set-upstream origin maimai-staging
 
       - name: Run constants script and capture output
-        id: run_script
         run: |
-          {
-            echo "OUTPUT_LOG<<EOF"
-            python scripts/update-const.py --maimai --all --nocolors --escape --markdown --no_timestamp --no_verbose
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
+          python -u scripts/update-const.py --maimai --all --nocolors --escape --markdown --no_timestamp --no_verbose 2>&1 | tee output.log
 
       - name: Extract datestamp from script output
         id: extract_date
@@ -83,17 +78,11 @@ jobs:
       - name: Checkout existing PR or create new
         if: steps.commit_changes.outputs.HAS_DIFFS == 'true'
         run: |
-          if [[ $(gh pr list --state open --head maimai-staging | grep maimai-staging) ]]; then
-            echo "PR currently open. Add comment to existing open PR"
-            gh pr comment maimai-staging \
-              --body "${{ steps.run_script.outputs.OUTPUT_LOG }}"
-          else
-            echo "No currently open PR for maimai-staging. Create new PR"
-            gh pr create \
-              -B ${{ github.ref_name }} \
-              -H "maimai-staging" \
-              --title "[Automation] maimai: Update website with updated song data (${{ steps.extract_date.outputs.DATESTAMP }})" \
-              --body "${{ steps.run_script.outputs.OUTPUT_LOG }}"
-          fi
+          python scripts/post-pr.py \
+            --head "maimai-staging" \
+            --base "${{ github.ref_name }}" \
+            --title "[Automation] maimai: Update website with updated song data (${{ steps.extract_date.outputs.DATESTAMP }})" \
+            --log-file "output.log"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.github/workflows/maimai-update-intl.yml
+++ b/.github/workflows/maimai-update-intl.yml
@@ -49,13 +49,8 @@ jobs:
           # git push --force --set-upstream origin maimai-staging
 
       - name: Run wiki script and capture output
-        id: run_script
         run: |
-          {
-            echo "OUTPUT_LOG<<EOF"
-            python -u scripts/update-intl.py --maimai --nocolors --escape --markdown --no_timestamp --no_verbose | tee /dev/stderr
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
+          python -u scripts/update-intl.py --maimai --nocolors --escape --markdown --no_timestamp --no_verbose 2>&1 | tee output.log
 
       - name: Extract datestamp from script output
         id: extract_date
@@ -83,17 +78,11 @@ jobs:
       - name: Checkout existing PR or create new
         if: steps.commit_changes.outputs.HAS_DIFFS == 'true'
         run: |
-          if [[ $(gh pr list --state open --head maimai-staging | grep maimai-staging) ]]; then
-            echo "PR currently open. Add comment to existing open PR"
-            gh pr comment maimai-staging \
-              --body "${{ steps.run_script.outputs.OUTPUT_LOG }}"
-          else
-            echo "No currently open PR for maimai-staging. Create new PR"
-            gh pr create \
-              -B ${{ github.ref_name }} \
-              -H "maimai-staging" \
-              --title "[Automation] maimai: Update website with updated song data (${{ steps.extract_date.outputs.DATESTAMP }})" \
-              --body "${{ steps.run_script.outputs.OUTPUT_LOG }}"
-          fi
+          python scripts/post-pr.py \
+            --head "maimai-staging" \
+            --base "${{ github.ref_name }}" \
+            --title "[Automation] maimai: Update website with updated song data (${{ steps.extract_date.outputs.DATESTAMP }})" \
+            --log-file "output.log"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.github/workflows/maimai-update-songs.yml
+++ b/.github/workflows/maimai-update-songs.yml
@@ -49,13 +49,8 @@ jobs:
           # git push --force --set-upstream origin maimai-staging
 
       - name: Run main script and capture output
-        id: run_script
         run: |
-          {
-            echo "OUTPUT_LOG<<EOF"
-            python scripts/update-songs.py --maimai --nocolors --escape --markdown --no_timestamp --no_verbose
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
+          python -u scripts/update-songs.py --maimai --nocolors --escape --markdown --no_timestamp --no_verbose 2>&1 | tee output.log
 
       - name: Extract datestamp from script output
         id: extract_date
@@ -64,16 +59,6 @@ jobs:
           # Use today's date instead because maimai default json doesn't have date data...
           # echo "datestamp=$(date '+%Y%m%d')" >> "$GITHUB_OUTPUT"
 
-      # - name: Check script output
-      #   id: check_script
-      #   run: |
-      #     if [[ "${{ steps.run_script.outputs.OUTPUT_LOG }}" == *"New song added"* ]]; then
-      #       echo "New song data downloaded. Creating a pull request."
-      #       echo "CREATE_PR=true" >> "$GITHUB_OUTPUT"
-      #     else
-      #       echo "Nothing updated. Skipping pull request creation."
-      #       echo "CREATE_PR=false" >> "$GITHUB_OUTPUT"
-      #     fi
 
       - name: Commit changes
         id: commit_changes
@@ -95,17 +80,11 @@ jobs:
       - name: Checkout existing PR or create new
         if: steps.commit_changes.outputs.HAS_DIFFS == 'true'
         run: |
-          if [[ $(gh pr list --state open --head maimai-staging | grep maimai-staging) ]]; then
-            echo "PR currently open. Add comment to existing open PR"
-            gh pr comment maimai-staging \
-              --body "${{ steps.run_script.outputs.OUTPUT_LOG }}"
-          else
-            echo "No currently open PR for maimai-staging. Create new PR"
-            gh pr create \
-              -B ${{ github.ref_name }} \
-              -H "maimai-staging" \
-              --title "[Automation] maimai: Add new songs (${{ steps.extract_date.outputs.DATESTAMP }})" \
-              --body "${{ steps.run_script.outputs.OUTPUT_LOG }}"
-          fi
+          python scripts/post-pr.py \
+            --head "maimai-staging" \
+            --base "${{ github.ref_name }}" \
+            --title "[Automation] maimai: Add new songs (${{ steps.extract_date.outputs.DATESTAMP }})" \
+            --log-file "output.log"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.github/workflows/maimai-update-wiki-all.yml
+++ b/.github/workflows/maimai-update-wiki-all.yml
@@ -47,13 +47,8 @@ jobs:
           # git push --force --set-upstream origin maimai-staging
 
       - name: Run wiki script and capture output
-        id: run_script
         run: |
-          {
-            echo "OUTPUT_LOG<<EOF"
-            python scripts/update-wiki-data.py --maimai --all --nocolors --escape --markdown --noskip --no_timestamp --no_verbose
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
+          python -u scripts/update-wiki-data.py --maimai --all --nocolors --escape --markdown --noskip --no_timestamp --no_verbose 2>&1 | tee output.log
 
       - name: Extract datestamp from script output
         id: extract_date
@@ -81,17 +76,11 @@ jobs:
       - name: Checkout existing PR or create new
         if: steps.commit_changes.outputs.HAS_DIFFS == 'true'
         run: |
-          if [[ $(gh pr list --state open --head maimai-staging | grep maimai-staging) ]]; then
-            echo "PR currently open. Add comment to existing open PR"
-            gh pr comment maimai-staging \
-              --body "${{ steps.run_script.outputs.OUTPUT_LOG }}"
-          else
-            echo "No currently open PR for maimai-staging. Create new PR"
-            gh pr create \
-              -B ${{ github.ref_name }} \
-              -H "maimai-staging" \
-              --title "[Automation] maimai: Update website with updated song data (all songs)" \
-              --body "${{ steps.run_script.outputs.OUTPUT_LOG }}"
-          fi
+          python scripts/post-pr.py \
+            --head "maimai-staging" \
+            --base "${{ github.ref_name }}" \
+            --title "[Automation] maimai: Update website with updated song data (all songs)" \
+            --log-file "output.log"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.github/workflows/maimai-update-wiki.yml
+++ b/.github/workflows/maimai-update-wiki.yml
@@ -49,13 +49,8 @@ jobs:
           # git push --force --set-upstream origin maimai-staging
 
       - name: Run wiki script and capture output
-        id: run_script
         run: |
-          {
-            echo "OUTPUT_LOG<<EOF"
-            python scripts/update-wiki-data.py --maimai --nocolors --escape --markdown --noskip --no_timestamp --no_verbose
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
+          python -u scripts/update-wiki-data.py --maimai --nocolors --escape --markdown --noskip --no_timestamp --no_verbose 2>&1 | tee output.log
 
       - name: Extract datestamp from script output
         id: extract_date
@@ -83,17 +78,11 @@ jobs:
       - name: Checkout existing PR or create new
         if: steps.commit_changes.outputs.HAS_DIFFS == 'true'
         run: |
-          if [[ $(gh pr list --state open --head maimai-staging | grep maimai-staging) ]]; then
-            echo "PR currently open. Add comment to existing open PR"
-            gh pr comment maimai-staging \
-              --body "${{ steps.run_script.outputs.OUTPUT_LOG }}"
-          else
-            echo "No currently open PR for maimai-staging. Create new PR"
-            gh pr create \
-              -B ${{ github.ref_name }} \
-              -H "maimai-staging" \
-              --title "[Automation] maimai: Update website with updated song data (${{ steps.extract_date.outputs.DATESTAMP }})" \
-              --body "${{ steps.run_script.outputs.OUTPUT_LOG }}"
-          fi
+          python scripts/post-pr.py \
+            --head "maimai-staging" \
+            --base "${{ github.ref_name }}" \
+            --title "[Automation] maimai: Update website with updated song data (${{ steps.extract_date.outputs.DATESTAMP }})" \
+            --log-file "output.log"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.github/workflows/ongeki-update-constants.yml
+++ b/.github/workflows/ongeki-update-constants.yml
@@ -49,13 +49,8 @@ jobs:
           # git push --force --set-upstream origin ongeki-staging
 
       - name: Run constants script and capture output
-        id: run_script
         run: |
-          {
-            echo "OUTPUT_LOG<<EOF"
-            python scripts/update-const.py --ongeki --all --nocolors --escape --markdown --no_timestamp --no_verbose
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
+          python -u scripts/update-const.py --ongeki --all --nocolors --escape --markdown --no_timestamp --no_verbose 2>&1 | tee output.log
 
       - name: Extract datestamp from script output
         id: extract_date
@@ -83,17 +78,11 @@ jobs:
       - name: Checkout existing PR or create new
         if: steps.commit_changes.outputs.HAS_DIFFS == 'true'
         run: |
-          if [[ $(gh pr list --state open --head ongeki-staging | grep ongeki-staging) ]]; then
-            echo "PR currently open. Add comment to existing open PR"
-            gh pr comment ongeki-staging \
-              --body "${{ steps.run_script.outputs.OUTPUT_LOG }}"
-          else
-            echo "No currently open PR for ongeki-staging. Create new PR"
-            gh pr create \
-              -B ${{ github.ref_name }} \
-              -H "ongeki-staging" \
-              --title "[Automation] Ongeki: Update website with updated song data (${{ steps.extract_date.outputs.DATESTAMP }})" \
-              --body "${{ steps.run_script.outputs.OUTPUT_LOG }}"
-          fi
+          python scripts/post-pr.py \
+            --head "ongeki-staging" \
+            --base "${{ github.ref_name }}" \
+            --title "[Automation] Ongeki: Update website with updated song data (${{ steps.extract_date.outputs.DATESTAMP }})" \
+            --log-file "output.log"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.github/workflows/ongeki-update-songs.yml
+++ b/.github/workflows/ongeki-update-songs.yml
@@ -49,28 +49,12 @@ jobs:
           # git push --force --set-upstream origin ongeki-staging
 
       - name: Run main script and capture output
-        id: run_script
         run: |
-          {
-            echo "OUTPUT_LOG<<EOF"
-            python scripts/update-songs.py --ongeki --nocolors --escape --markdown --no_timestamp --no_verbose
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
+          python -u scripts/update-songs.py --ongeki --nocolors --escape --markdown --no_timestamp --no_verbose 2>&1 | tee output.log
 
       - name: Extract datestamp from script output
         id: extract_date
         run: echo "datestamp=$(cat ongeki/data/music-ex.json | jq '.[-1].date_added | tonumber')" >> "$GITHUB_OUTPUT"
-
-      # - name: Check script output
-      #   id: check_script
-      #   run: |
-      #     if [[ "${{ steps.run_script.outputs.OUTPUT_LOG }}" == *"New song added"* ]]; then
-      #       echo "New song data downloaded. Creating a pull request."
-      #       echo "CREATE_PR=true" >> "$GITHUB_OUTPUT"
-      #     else
-      #       echo "Nothing updated. Skipping pull request creation."
-      #       echo "CREATE_PR=false" >> "$GITHUB_OUTPUT"
-      #     fi
 
       - name: Commit changes
         id: commit_changes
@@ -92,17 +76,11 @@ jobs:
       - name: Checkout existing PR or create new
         if: steps.commit_changes.outputs.HAS_DIFFS == 'true'
         run: |
-          if [[ $(gh pr list --state open --head ongeki-staging | grep ongeki-staging) ]]; then
-            echo "PR currently open. Add comment to existing open PR"
-            gh pr comment ongeki-staging \
-              --body "${{ steps.run_script.outputs.OUTPUT_LOG }}"
-          else
-            echo "No currently open PR for ongeki-staging. Create new PR"
-            gh pr create \
-              -B ${{ github.ref_name }} \
-              -H "ongeki-staging" \
-              --title "[Automation] Ongeki: Add new songs (${{ steps.extract_date.outputs.DATESTAMP }})" \
-              --body "${{ steps.run_script.outputs.OUTPUT_LOG }}"
-          fi
+          python scripts/post-pr.py \
+            --head "ongeki-staging" \
+            --base "${{ github.ref_name }}" \
+            --title "[Automation] Ongeki: Add new songs (${{ steps.extract_date.outputs.DATESTAMP }})" \
+            --log-file "output.log"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.github/workflows/ongeki-update-wiki-chartguide-all.yml
+++ b/.github/workflows/ongeki-update-wiki-chartguide-all.yml
@@ -47,14 +47,11 @@ jobs:
           # git push --force --set-upstream origin ongeki-staging
 
       - name: Run wiki script and capture output
-        id: run_script
         run: |
           {
-            echo "OUTPUT_LOG<<EOF"
-            python scripts/update-wiki-data.py --ongeki --all --nocolors --escape --markdown --noskip --no_timestamp --no_verbose
-            python scripts/update-chartguide-data.py --ongeki --all --nocolors --escape --markdown --no_timestamp --no_verbose
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
+            python -u scripts/update-wiki-data.py --ongeki --all --nocolors --escape --markdown --noskip --no_timestamp --no_verbose
+            python -u scripts/update-chartguide-data.py --ongeki --all --nocolors --escape --markdown --no_timestamp --no_verbose
+          } 2>&1 | tee output.log
 
       - name: Extract datestamp from script output
         id: extract_date
@@ -80,17 +77,11 @@ jobs:
       - name: Checkout existing PR or create new
         if: steps.commit_changes.outputs.HAS_DIFFS == 'true'
         run: |
-          if [[ $(gh pr list --state open --head ongeki-staging | grep ongeki-staging) ]]; then
-            echo "Add comment to existing open PR"
-            gh pr comment ongeki-staging \
-              --body "${{ steps.run_script.outputs.OUTPUT_LOG }}"
-          else
-            echo "No currently open PR for ongeki-staging. Create new PR"
-            gh pr create \
-              -B ${{ github.ref_name }} \
-              -H "ongeki-staging" \
-              --title "[Automation] Ongeki: Update website with updated song data (all songs)" \
-              --body "${{ steps.run_script.outputs.OUTPUT_LOG }}"
-          fi
+          python scripts/post-pr.py \
+            --head "ongeki-staging" \
+            --base "${{ github.ref_name }}" \
+            --title "[Automation] Ongeki: Update website with updated song data (all songs)" \
+            --log-file "output.log"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/.github/workflows/ongeki-update-wiki-chartguide.yml
+++ b/.github/workflows/ongeki-update-wiki-chartguide.yml
@@ -49,14 +49,11 @@ jobs:
           # git push --force --set-upstream origin ongeki-staging
 
       - name: Run wiki script and capture output
-        id: run_script
         run: |
           {
-            echo "OUTPUT_LOG<<EOF"
-            python scripts/update-wiki-data.py --ongeki --nocolors --escape --markdown --noskip --no_timestamp --no_verbose
-            python scripts/update-chartguide-data.py --ongeki --nocolors --escape --markdown --no_timestamp --no_verbose
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
+            python -u scripts/update-wiki-data.py --ongeki --nocolors --escape --markdown --noskip --no_timestamp --no_verbose
+            python -u scripts/update-chartguide-data.py --ongeki --nocolors --escape --markdown --no_timestamp --no_verbose
+          } 2>&1 | tee output.log
 
       - name: Extract datestamp from script output
         id: extract_date
@@ -82,17 +79,11 @@ jobs:
       - name: Checkout existing PR or create new
         if: steps.commit_changes.outputs.HAS_DIFFS == 'true'
         run: |
-          if [[ $(gh pr list --state open --head ongeki-staging | grep ongeki-staging) ]]; then
-            echo "Add comment to existing open PR"
-            gh pr comment ongeki-staging \
-              --body "${{ steps.run_script.outputs.OUTPUT_LOG }}"
-          else
-            echo "No currently open PR for ongeki-staging. Create new PR"
-            gh pr create \
-              -B ${{ github.ref_name }} \
-              -H "ongeki-staging" \
-              --title "[Automation] Ongeki: Update website with updated song data (${{ steps.extract_date.outputs.DATESTAMP }})" \
-              --body "${{ steps.run_script.outputs.OUTPUT_LOG }}"
-          fi
+          python scripts/post-pr.py \
+            --head "ongeki-staging" \
+            --base "${{ github.ref_name }}" \
+            --title "[Automation] Ongeki: Update website with updated song data (${{ steps.extract_date.outputs.DATESTAMP }})" \
+            --log-file "output.log"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/scripts/post-pr.py
+++ b/scripts/post-pr.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""
+Centralized script for creating or commenting on pull requests in GitHub Actions.
+Safely chunks long output logs to prevent shell argument limits (ARG_MAX) and
+GitHub API body character limits (65,536 characters).
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+MAX_CHUNK_SIZE = 60000  # Safe buffer below GitHub's 65,536 character limit
+
+
+def chunk_markdown(text: str, max_size: int = MAX_CHUNK_SIZE) -> list[str]:
+    """
+    Splits markdown text into line-safe chunks within character limits,
+    preserving code block formatting across chunks when split.
+    """
+    clean_text = text.strip()
+    if not clean_text:
+        return ["_No output log provided._"]
+
+    if len(clean_text) <= max_size:
+        return [clean_text]
+
+    chunks: list[str] = []
+    current_lines: list[str] = []
+    current_length = 0
+    in_code_block = False
+    fence_marker = "```"
+
+    for line in text.splitlines(keepends=True):
+        line_len = len(line)
+
+        # In case a single line is excessively long (> max_size)
+        if line_len > max_size:
+            # Flush existing lines first
+            if current_lines:
+                if in_code_block:
+                    current_lines.append(f"\n{fence_marker}\n")
+                chunks.append("".join(current_lines))
+                current_lines = []
+                current_length = 0
+                if in_code_block:
+                    current_lines.append(f"{fence_marker}\n")
+                    current_length += len(current_lines[0])
+
+            # Slice the long line into pieces
+            start = 0
+            while start < line_len:
+                sub_slice = line[start : start + max_size]
+                if in_code_block and start > 0:
+                    chunks.append(f"{fence_marker}\n{sub_slice}\n{fence_marker}")
+                else:
+                    chunks.append(sub_slice)
+                start += max_size
+            continue
+
+        if current_length + line_len > max_size and current_lines:
+            if in_code_block:
+                current_lines.append(f"\n{fence_marker}\n")
+            chunks.append("".join(current_lines))
+            current_lines = []
+            current_length = 0
+
+            if in_code_block:
+                current_lines.append(f"{fence_marker}\n")
+                current_length += len(current_lines[0])
+
+        stripped = line.strip()
+        if stripped.startswith("```"):
+            in_code_block = not in_code_block
+            if in_code_block:
+                fence_marker = stripped[: stripped.find(" ") if " " in stripped else len(stripped)]
+                if not fence_marker:
+                    fence_marker = "```"
+
+        current_lines.append(line)
+        current_length += line_len
+
+    if current_lines:
+        chunks.append("".join(current_lines))
+
+    total = len(chunks)
+    if total > 1:
+        return [
+            f"### 📝 Update Log (Part {i + 1}/{total})\n\n{chunk.strip()}"
+            for i, chunk in enumerate(chunks)
+        ]
+    return [chunk.strip() for chunk in chunks]
+
+
+def run_gh(*args: str) -> subprocess.CompletedProcess:
+    """Executes a gh CLI command and prints outputs."""
+    cmd = ["gh", *args]
+    print(f"Running: {' '.join(cmd[:4])} ...")
+    res = subprocess.run(cmd, text=True, capture_output=True)
+    if res.returncode != 0:
+        print(f"Error running gh command: {res.stderr}", file=sys.stderr)
+        res.check_returncode()
+    return res
+
+
+def is_pr_open(head: str) -> bool:
+    """Checks if there is already an open pull request for the head branch."""
+    res = subprocess.run(
+        ["gh", "pr", "list", "--state", "open", "--head", head, "--json", "number"],
+        text=True,
+        capture_output=True,
+    )
+    if res.returncode != 0:
+        print(f"Warning: Failed to list PRs: {res.stderr}", file=sys.stderr)
+        return False
+
+    try:
+        prs = json.loads(res.stdout.strip() or "[]")
+        return len(prs) > 0
+    except json.JSONDecodeError:
+        return bool(res.stdout.strip() and res.stdout.strip() != "[]")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Create or comment on a pull request with automatic log chunking."
+    )
+    parser.add_argument("--head", required=True, help="Head branch (e.g. maimai-staging)")
+    parser.add_argument("--base", default="master", help="Base branch (default: master)")
+    parser.add_argument("--title", required=True, help="Pull request title")
+    parser.add_argument("--log-file", required=True, help="Path to the output log file")
+
+    args = parser.parse_args()
+
+    log_path = Path(args.log_file)
+    log_text = ""
+    if log_path.exists():
+        try:
+            log_text = log_path.read_text(encoding="utf-8")
+        except Exception as e:
+            print(f"Warning: Failed to read {log_path}: {e}", file=sys.stderr)
+
+    chunks = chunk_markdown(log_text)
+    total_chunks = len(chunks)
+    print(f"Log prepared: {len(log_text)} chars divided into {total_chunks} chunk(s).")
+
+    has_open_pr = is_pr_open(args.head)
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp_path = Path(tmp_dir)
+
+        if has_open_pr:
+            print(f"Found existing open PR for '{args.head}'. Posting {total_chunks} comment(s)...")
+            for i, chunk in enumerate(chunks, start=1):
+                comment_file = tmp_path / f"comment_{i}.md"
+                comment_file.write_text(chunk, encoding="utf-8")
+                run_gh("pr", "comment", args.head, "--body-file", str(comment_file))
+                print(f"Successfully posted comment part {i}/{total_chunks}.")
+        else:
+            print(f"No existing PR found for '{args.head}'. Creating new PR...")
+            pr_body_file = tmp_path / "pr_body.md"
+            pr_body_file.write_text(chunks[0], encoding="utf-8")
+            res = run_gh(
+                "pr",
+                "create",
+                "--base",
+                args.base,
+                "--head",
+                args.head,
+                "--title",
+                args.title,
+                "--body-file",
+                str(pr_body_file),
+            )
+            print(f"Successfully created PR: {res.stdout.strip()}")
+
+            if total_chunks > 1:
+                print(f"Posting {total_chunks - 1} follow-up comment(s)...")
+                for i, chunk in enumerate(chunks[1:], start=2):
+                    comment_file = tmp_path / f"comment_{i}.md"
+                    comment_file.write_text(chunk, encoding="utf-8")
+                    run_gh("pr", "comment", args.head, "--body-file", str(comment_file))
+                    print(f"Successfully posted follow-up comment part {i}/{total_chunks}.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Workflow runs (e.g. #1363) could fail when creating a PR because large output logs were packed into `$GITHUB_OUTPUT` and expanded into shell command arguments (`gh pr create --body "${{ steps.run_script.outputs.OUTPUT_LOG }}"`), hitting the OS argument limit (`ARG_MAX` / `execve` error: `gh: Argument list too long`). Additionally, GitHub enforces a strict 65,536-character limit on PR and comment bodies.

### Changes
1. **New helper script [scripts/post-pr.py](https://github.com/zvuc/otoge-db/blob/fix/workflow-pr-log-chunking/scripts/post-pr.py)**:
   - Centralizes PR creation and commenting logic.
   - Chunks log output into line-safe parts (default max 60,000 characters), preserving code block formatting.
   - If creating a new PR: sets Part 1 as the PR body and posts subsequent parts as follow-up comments.
   - If updating an existing PR: posts all parts as follow-up comments.
   - Uses `--body-file` to avoid passing large strings as CLI arguments.
2. **Updated all 14 update workflows**:
   - Stream output directly to `output.log` using `2>&1 | tee output.log`.
   - Replaced duplicated bash PR creation blocks with `python scripts/post-pr.py`.